### PR TITLE
Add development SNS dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# API token for SNS provider
+API_TOKEN=your_api_token_here
+# Server port
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sns_dashboard",
+  "version": "1.0.0",
+  "description": "SNS account analysis dashboard",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,12 @@
+async function loadInsights() {
+  const accountId = document.getElementById('accountId').value || 'default';
+  const res = await fetch(`/api/insights?accountId=${encodeURIComponent(accountId)}`);
+  const data = await res.json();
+  document.getElementById('followers').textContent = data.followers;
+  document.getElementById('engagement').textContent = data.engagement;
+  document.getElementById('likes').textContent = data.likes;
+  document.getElementById('comments').textContent = data.comments;
+}
+
+document.getElementById('load').addEventListener('click', loadInsights);
+loadInsights();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>SNS Dashboard</title>
+  </head>
+  <body>
+    <h1>SNSアカウント分析ダッシュボード</h1>
+    <div>
+      <label for="accountId">アカウントID:</label>
+      <input id="accountId" type="text" placeholder="default" />
+      <button id="load">読み込み</button>
+    </div>
+    <table border="1">
+      <tr><th>フォロワー</th><td id="followers"></td></tr>
+      <tr><th>エンゲージメント</th><td id="engagement"></td></tr>
+      <tr><th>いいね</th><td id="likes"></td></tr>
+      <tr><th>コメント</th><td id="comments"></td></tr>
+    </table>
+    <script src="/dashboard.js"></script>
+  </body>
+</html>

--- a/readme
+++ b/readme
@@ -1,33 +1,24 @@
 # SNS Dashboard
 
 ## 概要
-SNS Dashboardは、複数のSNSアカウントを一元管理するためのツールです。投稿のスケジュール管理、分析、通知機能などを提供します。
-
-## 主な機能
-- **投稿スケジュール管理**: 各SNSプラットフォームへの投稿を簡単にスケジュール設定。
-- **分析機能**: 投稿のパフォーマンスを可視化し、インサイトを提供。
-- **通知機能**: フォロワーの増減やエンゲージメントの変化を通知。
+SNS Dashboardは、SNSアカウントのインサイト情報を取得して表示する開発用ダッシュボードです。APIからフォロワー数やエンゲージメントなどのデータを取得し、ブラウザ上で確認できます。開発モードではモックデータを利用します。
 
 ## 使用方法
 1. リポジトリをクローンします。
-  ```
-  git clone https://github.com/yourusername/sns_dashboard.git
-  ```
-2. 必要な依存関係をインストールします。
-  ```
-  npm install
-  ```
-3. アプリケーションを起動します。
-  ```
-  npm start
-  ```
+2. `.env.example` を `.env` にコピーし、必要に応じて `API_TOKEN` を設定します。
+3. アプリケーションを開発モードで起動します。
+   ```
+   NODE_ENV=development npm start
+   ```
+4. ブラウザで [http://localhost:3000](http://localhost:3000) を開きます。
+
+## テスト
+```
+npm test
+```
 
 ## 必要条件
-- Node.js v14以上
-- npm v6以上
-
-## 貢献
-バグ報告や機能提案は、[Issues](https://github.com/yourusername/sns_dashboard/issues)からお願いします。プルリクエストも歓迎します。
+- Node.js v20以上
 
 ## ライセンス
-このプロジェクトはMITライセンスのもとで公開されています。詳細は[LICENSE](./LICENSE)ファイルをご覧ください。
+MIT

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,26 @@
+const mockData = require('./mockData');
+
+const API_URL = 'https://api.example.com/insights';
+
+async function fetchInsights(accountId) {
+  const id = accountId || 'default';
+  // Use mock data in development mode or when API token is missing
+  if (process.env.NODE_ENV === 'development' || !process.env.API_TOKEN) {
+    return mockData[id] || mockData.default;
+  }
+
+  const url = `${API_URL}?account=${encodeURIComponent(id)}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${process.env.API_TOKEN}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`API request failed with status ${res.status}`);
+  }
+
+  return res.json();
+}
+
+module.exports = { fetchInsights };

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+process.env.NODE_ENV = 'development';
+const { fetchInsights } = require('./api');
+
+test('fetchInsights returns mock data in development mode', async () => {
+  const data = await fetchInsights('default');
+  assert.strictEqual(typeof data.followers, 'number');
+  assert.strictEqual(typeof data.engagement, 'number');
+});

--- a/src/mockData.js
+++ b/src/mockData.js
@@ -1,0 +1,14 @@
+module.exports = {
+  default: {
+    followers: 1200,
+    engagement: 0.05,
+    likes: 320,
+    comments: 25
+  },
+  sample: {
+    followers: 5000,
+    engagement: 0.12,
+    likes: 1500,
+    comments: 120
+  }
+};

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,58 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { fetchInsights } = require('./api');
+
+const PORT = process.env.PORT || 3000;
+
+const server = http.createServer(async (req, res) => {
+  // API endpoint for insights
+  if (req.url.startsWith('/api/insights')) {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const accountId = url.searchParams.get('accountId');
+    try {
+      const data = await fetchInsights(accountId);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.message }));
+    }
+    return;
+  }
+
+  // Static file serving
+  const filePath = path.join(
+    __dirname,
+    '..',
+    'public',
+    req.url === '/' ? 'index.html' : req.url
+  );
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType =
+      ext === '.js'
+        ? 'application/javascript'
+        : ext === '.css'
+        ? 'text/css'
+        : 'text/html';
+
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
+});
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = server;


### PR DESCRIPTION
## Summary
- build simple Node dashboard serving insight data through API integration
- add mock data for development mode and minimal frontend
- include tests and environment setup

## Testing
- `npm test`
- `NODE_ENV=development PORT=3100 npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b3c6f090e0832f8bd76275778db932